### PR TITLE
Added support for horizontal scrolling content

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+	<declare-styleable name="VerticalViewPager">
+		<attr name="vvp_threshold" format="dimension"/>
+	</declare-styleable>
+
+</resources>


### PR DESCRIPTION
We now check for a certain y-axis touch distance and intercept if it
passes the threshold. This allows us to use horizontal scrolling content
such as a RecyclerView with a horizontal LinearLayoutManager inside
VerticalViewPager content.

Threshold may very depending on your layout. For example, if the
VerticalViewPager takes up a large amount of a height, the default
threshold (16dp) works perfectly. But if your VerticalViewPager takes up
less than half the screen height, then a smaller threshold would provide
a better user experience. For that reason, the threshold is customizable
via XML with the vvp_threshold attribute.

This has been tested extensively on a large-scale app that I'm currently
working on.
